### PR TITLE
Fix critical bug: can_use_ram_disk called with filename instead of nu…

### DIFF
--- a/src/lib/audio_processing.sh
+++ b/src/lib/audio_processing.sh
@@ -33,8 +33,8 @@ process_with_audio_conversion() {
     local temp_dir
     local use_ram_disk=false
 
-    # Determine if we can use RAM disk
-    if can_use_ram_disk "$input_file"; then
+    # Determine if we can use RAM disk (need minimum 100MB)
+    if can_use_ram_disk 100; then
         use_ram_disk=true
         temp_dir=$(mktemp -d -p "$RAM_DISK_PATH")
         log_debug "Using RAM disk for temporary files: $temp_dir"

--- a/src/lib/utils.sh
+++ b/src/lib/utils.sh
@@ -194,6 +194,11 @@ suggest_error_recovery() {
 can_use_ram_disk() {
     local min_size_mb=${1:-100}  # Default minimum size 100MB
     local tmpfs_path="/dev/shm"
+    
+    # Validate that min_size_mb is numeric
+    if [[ ! "$min_size_mb" =~ ^[0-9]+$ ]]; then
+        min_size_mb=100
+    fi
 
     # Check if /dev/shm exists and is mounted
     if [[ ! -d "$tmpfs_path" ]]; then
@@ -214,7 +219,10 @@ can_use_ram_disk() {
     fi
 
     # Convert KB to MB and compare
-    local available_mb=$((available_kb / 1024))
+    local available_mb
+    if ! available_mb=$((available_kb / 1024)) 2>/dev/null; then
+        return 1
+    fi
 
     if [[ "$available_mb" -gt "$min_size_mb" ]]; then
         return 0
@@ -227,6 +235,11 @@ can_use_ram_disk() {
 can_use_ram_disk_with_memory_check() {
     local min_size_mb=${1:-100}
     local tmpfs_path="/dev/shm"
+    
+    # Validate that min_size_mb is numeric
+    if [[ ! "$min_size_mb" =~ ^[0-9]+$ ]]; then
+        min_size_mb=100
+    fi
 
     # First check basic tmpfs availability
     if ! can_use_ram_disk "$min_size_mb"; then


### PR DESCRIPTION
…meric size

- Fixed audio_processing.sh line 37: was passing $input_file (filename) instead of numeric size parameter
- Added numeric validation to both can_use_ram_disk functions to prevent similar issues
- Added safer arithmetic expansion with error handling in can_use_ram_disk
- This fixes the syntax error: operand expected when processing video files